### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.svelte-starter-web
+++ b/Dockerfile.svelte-starter-web
@@ -1,0 +1,25 @@
+FROM node:18.12.0-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the code
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Install serve to serve the static site
+RUN npm install -g serve
+
+# Expose the port the app runs on
+EXPOSE 80
+
+# Serve the static site
+CMD ["serve", "-s", "build", "-l", "80"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO svelte-starter
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,41 @@
+namespace: svelte-starter
+
+svelte-starter-web:
+  defines: runnable
+  metadata:
+    name: svelte-starter-web
+    description: Static web service for the SvelteKit application
+    icon: https://emojiapi.dev/api/v1/globe_with_meridians.svg
+  containers:
+    svelte-starter-web:
+      image: env-5051.registry.local/svelte-starter-web:main-mh0cuw
+      build: .
+      dockerfile: Dockerfile.svelte-starter-web
+  services:
+    http:
+      description: HTTP port for web traffic
+      container: svelte-starter-web
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+    https:
+      description: HTTPS port for secure web traffic
+      container: svelte-starter-web
+      port: 443
+      host-port: 443
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - svelte-starter/svelte-starter-web
+  metadata:
+    name: svelte-starter
+    description: >-
+      A SvelteKit project designed for data-driven, visual stories that
+      generates a statically rendered site.
+    icon: https://emojiapi.dev/api/v1/globe_with_meridians.svg


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for SvelteKit Application

## Containerization
I've successfully containerized the SvelteKit application, `svelte-starter`, which is designed for data-driven, visual stories. The application is a static site that can be pre-rendered using SvelteKit with an adapter for static sites.

- **Dockerfile**: Created a `Dockerfile.svelte-starter-web` to build the SvelteKit application. It uses an appropriate Node.js base image, installs necessary dependencies, and builds the application using `vite build`.
- **Service Check**: Verified that the service is accepting connections at `http://localhost:80`. The Dockerfile uses `serve` to serve the static site, which is a common practice for static sites. The service is operational and serving content as expected.

## Deployment Configuration
I've written the deployment configuration for the application using Monk.io.

- **Monk Configuration**: Added a `monk.yaml` file that contains the Monk configuration for the application.
- **Manifest**: Included a `MANIFEST` file, which is required by Monk and lists all files containing Monk configurations.

## Instructions for Continuation
The process has been completed successfully. The application is ready to be re-deployed on each subsequent push. To continue, simply merge this PR, and the application will be containerized and configured for deployment using the provided Dockerfile and Monk.io configuration.

### Files Added
- `Dockerfile.svelte-starter-web`
- `monk.yaml`
- `MANIFEST`

No environment variables, connections, or ports are required for the operation of the `svelte-starter-web` service based on the current repository contents. The static nature of the application simplifies the deployment process, as there are no backend services or databases involved.